### PR TITLE
Small modifications for README instruction works.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 .project
 .settings/
 /bin/
+.idea

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An example application is included and is derived from a JavaScript version foun
 ### Getting started
 
 To get started, open `sbt` in this example project, and execute the task
-`fastOptJS`. This creates the file `target/scala-2.11/example-fastopt.js`.
+`fastOptJS`. This creates the file `target/scala-2.11/babylonjs-facade-fastopt.js`.
 You can now open `index-fastopt.html` in your favorite Web browser!
 
 During development, it is useful to use `~fastOptJS` in sbt, so that each

--- a/index-fastopt.html
+++ b/index-fastopt.html
@@ -23,13 +23,14 @@
 </head>
 <body>
 
-<div id="playground">
-</div>
 <canvas id="renderCanvas"></canvas>
+
 <script type="text/javascript" src="./dist/babylon.2.2.max.js"></script>
-<script type="text/javascript" src="./target/scala-2.11/example-fastopt.js"></script>
-<script type="text/javascript" src="./target/scala-2.11/example-launcher.js"></script>
-<!--  
+<script type="text/javascript" src="./target/scala-2.11/babylonjs-facade-fastopt.js"></script>
+<script type="text/javascript" src="./target/scala-2.11/babylonjs-facade-jsdeps.js"></script>
+<script>example.ScalaJSExample().main();</script>
+
+<!--
 <script>
 // This begins the creation of a function that we will 'call' just after it's built
 var createScene = function () {

--- a/index.html
+++ b/index.html
@@ -12,11 +12,12 @@
 (using `sbt fullOptJS`), you should see "It works" herebelow.
 See README.md for detailed explanations.</p>
 
-<div id="playground">
-</div>
+<canvas id="renderCanvas"></canvas>
 
-<script type="text/javascript" src="./target/scala-2.11/example-opt.js"></script>
-<script type="text/javascript" src="./target/scala-2.11/example-launcher.js"></script>
+<script type="text/javascript" src="./dist/babylon.2.2.max.js"></script>
+<script type="text/javascript" src="./target/scala-2.11/babylonjs-facade-opt.js"></script>
+<script type="text/javascript" src="./target/scala-2.11/babylonjs-facade-jsdeps.js"></script>
+<script>example.ScalaJSExample().main();</script>
 
 </body>
 </html>

--- a/src/main/scala/example/BabylonjsExample.scala
+++ b/src/main/scala/example/BabylonjsExample.scala
@@ -26,6 +26,9 @@ object ScalaJSExample extends js.JSApp {
     val sphere = Mesh.CreateSphere("sphere1", 16, 2, scene)
     sphere.position.y = 1
     val ground = Mesh.CreateGround("ground1", 6.0, 6.0, 2, scene)
-    engine.runRenderLoop(()=>{scene.render()})  
+    engine.runRenderLoop{()=>
+      scene.render()
+      ground.rotation.y += 0.005
+    }
   }
 }

--- a/src/main/scala/scalajs/facade/babylonjs/babylonjs.scala
+++ b/src/main/scala/scalajs/facade/babylonjs/babylonjs.scala
@@ -984,8 +984,11 @@ class ArcRotateCamera protected () extends TargetCamera {
   var inertialRadiusOffset: Double = js.native
   var lowerAlphaLimit: js.Any = js.native
   var upperAlphaLimit: js.Any = js.native
-  var lowerBetaLimit: Double = js.native
-  var upperBetaLimit: Double = js.native
+
+  // We must be able to set null to remove the limitation. http://www.html5gamedevs.com/topic/3279-unlimited-y-rotation-on-camera/#comment-21360
+  var lowerBetaLimit: js.Any = js.native
+  var upperBetaLimit: js.Any = js.native
+
   var lowerRadiusLimit: js.Any = js.native
   var upperRadiusLimit: js.Any = js.native
   var angularSensibilityX: Double = js.native


### PR DESCRIPTION
I've made some small modifications, now when I clone de project, then exec `sbt clean fastOptJS fullOptJS`. When I open `index.html` and `index-fastopt.html` I see the small example.
