### PR TITLE
Fixed SBT issues (project name and missing launcher generation).

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
+persistLauncher in Compile := true
+
 libraryDependencies ++= Seq(
     "org.scala-js" %%% "scalajs-dom" % "0.8.2",
 	"com.lihaoyi" %%% "scalatags" % "0.5.2"

--- a/index-fastopt.html
+++ b/index-fastopt.html
@@ -27,8 +27,8 @@
 </div>
 <canvas id="renderCanvas"></canvas>
 <script type="text/javascript" src="./dist/babylon.2.2.max.js"></script>
-<script type="text/javascript" src="./target/scala-2.11/example-fastopt.js"></script>
-<script type="text/javascript" src="./target/scala-2.11/example-launcher.js"></script>
+<script type="text/javascript" src="./target/scala-2.11/babylonjs-facade-fastopt.js"></script>
+<script type="text/javascript" src="./target/scala-2.11/babylonjs-facade-launcher.js"></script>
 <!--  
 <script>
 // This begins the creation of a function that we will 'call' just after it's built

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@ See README.md for detailed explanations.</p>
 <div id="playground">
 </div>
 
-<script type="text/javascript" src="./target/scala-2.11/example-opt.js"></script>
-<script type="text/javascript" src="./target/scala-2.11/example-launcher.js"></script>
+<script type="text/javascript" src="./target/scala-2.11/babylonjs-facade-opt.js"></script>
+<script type="text/javascript" src="./target/scala-2.11/babylonjs-facade-launcher.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Fixed SBT issues (project name and missing launcher generation).

Current index.html references target files as if the project is named "example", while in fact it is named "babylonjs-facade" in the `build.sbt` file.

Sbt is missing `persistLauncher` setting.